### PR TITLE
test: Ensure test assertions survive in release builds

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ foreach(SRC_NAME
 )
     set(TEST_NAME s3q_${SRC_NAME})
     add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${SRC_NAME}.cpp)
-    target_link_libraries(${TEST_NAME} PRIVATE s3q)
+    target_link_libraries(${TEST_NAME} PRIVATE s3q PRIVATE tlx-mini)
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
     add_dependencies(s3q_tests ${TEST_NAME})
 endforeach()

--- a/tests/batched_pq_test.cpp
+++ b/tests/batched_pq_test.cpp
@@ -6,7 +6,8 @@
 #include <range/v3/view/indices.hpp>
 #include <range/v3/view/transform.hpp>
 
-#include <cassert>
+#include <tlx/die.hpp>
+
 #include <cstddef>
 #include <vector>
 
@@ -28,20 +29,20 @@ int main() {
     auto batches = items | views::chunk(TestCfg::kBufBaseSize);
 
     for (auto b : batches) {
-        assert(ranges::size(b) == TestCfg::kBufBaseSize);
+        die_unless(ranges::size(b) == TestCfg::kBufBaseSize);
         bpq.insert(b);
     }
 
     int max_popped_key = 0;
     while (bpq.size() > 0) {
         auto bucket = bpq.delMin();
-        assert(bucket.buf.size() > 0);
+        die_unless(bucket.buf.size() > 0);
 
         auto keys = bucket.buf | views::transform(getKey);
         auto [kmin, kmax] = ranges::minmax(keys);
 
-        assert(max_popped_key < kmin);
-        assert(kmax <= bucket.sup);
+        die_unless(max_popped_key < kmin);
+        die_unless(kmax <= bucket.sup);
         max_popped_key = kmax;
     }
 }

--- a/tests/classifier_test.cpp
+++ b/tests/classifier_test.cpp
@@ -5,8 +5,9 @@
 #include <range/v3/core.hpp>
 #include <range/v3/view/iota.hpp>
 
+#include <tlx/die.hpp>
+
 #include <array>
-#include <cassert>
 
 struct TestCfg : s3q::detail::ExtendedCfg<> {
     static constexpr unsigned kLogMaxDegree = 2u;
@@ -20,29 +21,29 @@ int main() {
         int counts[4] = {0};
         classifier.build(std::array{2, 4, 6});
         classifier.classify(ints(1, 9), [&counts](auto cls, auto it) {
-            assert(*it <= (int(cls) + 1) * 2);
+            die_unless(*it <= (int(cls) + 1) * 2);
             ++counts[cls];
         });
-        assert(ranges::all_of(counts, [](auto c) { return c == 2; }));
+        die_unless(ranges::all_of(counts, [](auto c) { return c == 2; }));
     }
 
     { // #buckets = power of two that is less than the max
         int counts[2] = {0, 0};
         classifier.build(std::array{5});
         classifier.classify(ints(1, 11), [&counts](auto cls, auto it) {
-            assert(*it <= (int(cls) + 1) * 5);
+            die_unless(*it <= (int(cls) + 1) * 5);
             ++counts[cls];
         });
-        assert(ranges::all_of(counts, [](auto c) { return c == 5; }));
+        die_unless(ranges::all_of(counts, [](auto c) { return c == 5; }));
     }
 
     { // #buckets = not a power of two
         int counts[3] = {0};
         classifier.build(std::array{3, 6});
         classifier.classify(ints(1, 10), [&counts](auto cls, auto it) {
-            assert(*it <= (int(cls) + 1) * 3);
+            die_unless(*it <= (int(cls) + 1) * 3);
             ++counts[cls];
         });
-        assert(ranges::all_of(counts, [](auto c) { return c == 3; }));
+        die_unless(ranges::all_of(counts, [](auto c) { return c == 3; }));
     }
 }

--- a/tests/pq_test.cpp
+++ b/tests/pq_test.cpp
@@ -6,7 +6,8 @@
 #include <range/v3/view/indices.hpp>
 #include <range/v3/view/transform.hpp>
 
-#include <cassert>
+#include <tlx/die.hpp>
+
 #include <cstddef>
 #include <vector>
 
@@ -34,6 +35,6 @@ int main() {
     auto popped_keys =
         popped_items | views::transform(getKey) | ranges::to<std::vector>;
 
-    assert(pq.empty());
-    assert(ranges::equal(keys, popped_keys));
+    die_unless(pq.empty());
+    die_unless(ranges::equal(keys, popped_keys));
 }


### PR DESCRIPTION
Some tests used regular asserts which caused all asserts to become noops in release builds. This change avoids that by using `tlx/die` which is already used elsewhere.