### PR TITLE
build: allow deprecated FetchContent_Populate

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,5 +1,13 @@
 include(FetchContent)
 
+# Allow the FetchContent_Populate pattern we are using below.
+# We cannot switch directly to FetchContent_MakeAvailable since that will
+# always interpret the fetched dependencies' CMakeLists.txt files. This is not
+# what we want as we only grab a few headers in most cases.
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+endif()
+
 macro(fetch)
     FetchContent_Declare(${ARGV})
     FetchContent_GetProperties(${ARGV0})


### PR DESCRIPTION
Gets rid of these warnings:

```
CMake Warning (dev) at /usr/local/share/cmake-3.31/Modules/FetchContent.cmake:1953 (message):
  Calling FetchContent_Populate(tlx) is deprecated, call
  FetchContent_MakeAvailable(tlx) instead.  Policy CMP0169 can be set to OLD
  to allow FetchContent_Populate(tlx) to be called directly for now, but the
  ability to call it with declared details will be removed completely in a
  future version.
Call Stack (most recent call first):
  extern/CMakeLists.txt:7 (FetchContent_Populate)
  extern/CMakeLists.txt:29 (fetch)
This warning is for project developers.  Use -Wno-dev to suppress it.

```