### PR TITLE
test(batched_pq): convert input ranges to vectors

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,3 @@ foreach(SRC_NAME
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
     add_dependencies(s3q_tests ${TEST_NAME})
 endforeach()
-
-# TODO: raphinesse/s3q#5 - fix library so this test passes again
-set_tests_properties(s3q_batched_pq_test
-                     PROPERTIES DISABLED TRUE)

--- a/tests/batched_pq_test.cpp
+++ b/tests/batched_pq_test.cpp
@@ -28,7 +28,7 @@ int main() {
     auto keys = views::closed_indices(1, N);
     auto items = keys | views::transform(makeItem);
     auto batches = items | views::chunk(TestCfg::kBufBaseSize)
-                         | ranges::to<std::vector<std::vector<int>>>;
+                         | ranges::to<std::vector<std::vector<typename TestCfg::Item>>>;
 
     for (auto b : batches) {
         die_unless(ranges::size(b) == TestCfg::kBufBaseSize);

--- a/tests/batched_pq_test.cpp
+++ b/tests/batched_pq_test.cpp
@@ -27,12 +27,11 @@ int main() {
     namespace views = ranges::views;
     auto keys = views::closed_indices(1, N);
     auto items = keys | views::transform(makeItem);
-    auto batches = items | views::chunk(TestCfg::kBufBaseSize)
-                         | ranges::to<std::vector<std::vector<typename TestCfg::Item>>>;
+    auto batches = items | views::chunk(TestCfg::kBufBaseSize);
 
     for (auto b : batches) {
         die_unless(ranges::size(b) == TestCfg::kBufBaseSize);
-        bpq.insert(b);
+        bpq.insert(b | ranges::to<std::vector<TestCfg::Item>>);
     }
 
     int max_popped_key = 0;

--- a/tests/batched_pq_test.cpp
+++ b/tests/batched_pq_test.cpp
@@ -27,11 +27,12 @@ int main() {
     namespace views = ranges::views;
     auto keys = views::closed_indices(1, N);
     auto items = keys | views::transform(makeItem);
-    auto batches = items | views::chunk(TestCfg::kBufBaseSize);
+    auto batches = items | views::chunk(TestCfg::kBufBaseSize)
+                         | views::transform(ranges::to_vector);
 
     for (auto b : batches) {
         die_unless(ranges::size(b) == TestCfg::kBufBaseSize);
-        bpq.insert(b | ranges::to<std::vector<TestCfg::Item>>);
+        bpq.insert(b);
     }
 
     int max_popped_key = 0;

--- a/tests/batched_pq_test.cpp
+++ b/tests/batched_pq_test.cpp
@@ -5,6 +5,7 @@
 #include <range/v3/view/chunk.hpp>
 #include <range/v3/view/indices.hpp>
 #include <range/v3/view/transform.hpp>
+#include <range/v3/range/conversion.hpp>
 
 #include <tlx/die.hpp>
 
@@ -26,7 +27,8 @@ int main() {
     namespace views = ranges::views;
     auto keys = views::closed_indices(1, N);
     auto items = keys | views::transform(makeItem);
-    auto batches = items | views::chunk(TestCfg::kBufBaseSize);
+    auto batches = items | views::chunk(TestCfg::kBufBaseSize)
+                         | ranges::to<std::vector<std::vector<int>>>;
 
     for (auto b : batches) {
         die_unless(ranges::size(b) == TestCfg::kBufBaseSize);


### PR DESCRIPTION
Apparently we were going a bit overboard with all the `ranges::views` up to the point where some part of the program tried to take references of temporaries. Converting each test batch to a vector fixes these issues and also reflects what is passed to the batched PQ in reality.

Fixes #5 #8 