### PR TITLE
ci: add callgrind workflow

### DIFF
--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -39,3 +39,12 @@ jobs:
         --inclusive=yes --tree=both
         --show=D1mr,D1mw --sort=D1mr,D1mw
         callgrind.out.*
+        | tee cga_report.txt
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: callgrind
+        path: |
+          callgrind.out.*
+          cga_report.txt
+        

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Callgrind
       working-directory: ${{github.workspace}}/build
-      run: valgrind --tool=callgrind --cache-sim=yes ./bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
+      run: valgrind --tool=callgrind --cache-sim=yes ./benchmarks/bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
 
     - name: Show Results (exclusive)
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Callgrind
       working-directory: ${{github.workspace}}/build
-      run: valgrind --tool=callgrind --cache-sim=yes ./benchmarks/bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
+      run: valgrind --tool=callgrind --cache-sim=yes ../bin/bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
 
     - name: Show Results (exclusive)
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -25,7 +25,7 @@ jobs:
       run: cmake --build . --target bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
 
     - name: Install Callgrind
-      run: apt-get install valgrind
+      run: sudo apt install -y valgrind
 
     - name: Callgrind
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -11,7 +11,7 @@ env:
   BUILD_TYPE: RelWithDebInfo
 
 jobs:
-  build:
+  callgrind:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,18 +27,16 @@ jobs:
     - name: Install Callgrind
       run: sudo apt install -y valgrind
 
-    - name: Find bin
-      run: find . -type f -name 'bm_test_*'
-
     - name: Callgrind
-      run: valgrind --tool=callgrind --cache-sim=yes ./build/bin/bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
+      run: >
+        valgrind
+          --tool=callgrind --cache-sim=yes
+          ./build/bin/bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
 
-    - name: Show Results (exclusive)
-      run: callgrind_annotate callgrind.out.*
-
-    - name: Show Results (exclusive)
-      run: callgrind_annotate --inclusive=yes callgrind.out.*
-
-    - name: Show Results (tree)
-      run: callgrind_annotate --tree=both callgrind.out.*
-
+    - name: Show Results
+      run: >
+        callgrind_annotate
+          --inclusive=yes --tree=both
+          --show=D1mr,D1mw
+          --sort=D1mr,D1mw
+          callgrind.out.*

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -18,7 +18,10 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: >
+        CXXFLAGS=-fno-inline-functions
+        cmake -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -30,13 +30,12 @@ jobs:
     - name: Callgrind
       run: >
         valgrind
-          --tool=callgrind --cache-sim=yes
-          ./build/bin/bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
+        --tool=callgrind --cache-sim=yes
+        ./build/bin/bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
 
     - name: Show Results
       run: >
         callgrind_annotate
-          --inclusive=yes --tree=both
-          --show=D1mr,D1mw
-          --sort=D1mr,D1mw
-          callgrind.out.*
+        --inclusive=yes --tree=both
+        --show=D1mr,D1mw --sort=D1mr,D1mw
+        callgrind.out.*

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -31,7 +31,7 @@ jobs:
       run: find . -type f -name 'bm_test_*'
 
     - name: Callgrind
-      run: valgrind --tool=callgrind --cache-sim=yes ./bin/bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
+      run: valgrind --tool=callgrind --cache-sim=yes ./build/bin/bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
 
     - name: Show Results (exclusive)
       run: callgrind_annotate callgrind.out.*

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -1,0 +1,45 @@
+name: Callgrind
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+env:
+  BUILD_TYPE: RelWithDebInfo
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      run: cmake --build . --targets bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
+
+    - name: Install Callgrind
+      run: apt-get install valgrind
+
+    - name: Callgrind
+      working-directory: ${{github.workspace}}/build
+      run: valgrind --tool=callgrind --cache-sim=yes ./bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
+
+    - name: Show Results (exclusive)
+      working-directory: ${{github.workspace}}/build
+      run: callgrind_annotate callgrind.out.*
+
+    - name: Show Results (exclusive)
+      working-directory: ${{github.workspace}}/build
+      run: callgrind_annotate --inclusive=yes callgrind.out.*
+
+    - name: Show Results (tree)
+      working-directory: ${{github.workspace}}/build
+      run: callgrind_annotate --tree=both callgrind.out.*
+

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Configure CMake
       run: >
-        CXXFLAGS=-fno-inline-functions
+        CXXFLAGS=-fno-inline
         cmake -B ${{github.workspace}}/build
         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -27,19 +27,18 @@ jobs:
     - name: Install Callgrind
       run: sudo apt install -y valgrind
 
+    - name: Find bin
+      run: find . -type f -name 'bm_test_*'
+
     - name: Callgrind
-      working-directory: ${{github.workspace}}/build
-      run: valgrind --tool=callgrind --cache-sim=yes ../bin/bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
+      run: valgrind --tool=callgrind --cache-sim=yes ./bin/bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
 
     - name: Show Results (exclusive)
-      working-directory: ${{github.workspace}}/build
       run: callgrind_annotate callgrind.out.*
 
     - name: Show Results (exclusive)
-      working-directory: ${{github.workspace}}/build
       run: callgrind_annotate --inclusive=yes callgrind.out.*
 
     - name: Show Results (tree)
-      working-directory: ${{github.workspace}}/build
       run: callgrind_annotate --tree=both callgrind.out.*
 

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Build
       working-directory: ${{github.workspace}}/build
-      run: cmake --build . --targets bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
+      run: cmake --build . --target bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
 
     - name: Install Callgrind
       run: apt-get install valgrind

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -1,0 +1,53 @@
+name: Callgrind
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+env:
+  BUILD_TYPE: RelWithDebInfo
+
+jobs:
+  callgrind:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Configure CMake
+      run: >
+        CXXFLAGS=-fno-inline
+        cmake -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      run: cmake --build . --target bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
+
+    - name: Install Callgrind
+      run: sudo apt install -y valgrind
+
+    - name: Callgrind
+      run: >
+        valgrind
+        --tool=callgrind --cache-sim=yes
+        ./build/bin/bm_test_S3Q_6_15__Wiggle_0_RandomDriver_
+
+    - name: Show Results
+      run: >
+        callgrind_annotate
+        --inclusive=yes --tree=both
+        --show=D1mr,D1mw --sort=D1mr,D1mw
+        callgrind.out.*
+        | tee cga_report.txt
+
+    - uses: actions/upload-artifact@v7
+      with:
+        name: callgrind
+        path: |
+          callgrind.out.*
+          cga_report.txt
+        


### PR DESCRIPTION
Configures and builds a single benchmark target, runs it under Callgrind with cache simulation, annotates the output to show D1 cache miss totals, and uploads the raw profile and annotated report as a workflow artifact.